### PR TITLE
[feature/loginKakao] Add: Post Kakao login authorize code to server

### DIFF
--- a/src/components/Nav/Login/Login.js
+++ b/src/components/Nav/Login/Login.js
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { flexAlignCenter } from '../../../styles/mixin';
 
-const Login = ({ modalState, closeModal }) => {
+const Login = ({ loginModalState, closeLoginModal }) => {
   const KAKAO_OAUTH_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${process.env.REACT_APP_REST_API_KEY}&redirect_uri=${process.env.REACT_APP_REDIRECT_URI}&response_type=code`;
 
   const [userData, setUserData] = useState({
@@ -17,51 +17,59 @@ const Login = ({ modalState, closeModal }) => {
 
   const disabled = !(userData.id.length * userData.pw.length > 1);
 
-  if (!modalState) return null;
-
-  return (
-    <>
-      <Overlay onClick={closeModal} />
-      <LoginArea disabled={disabled}>
-        <LoginTop>
-          <span />
-          <button onClick={closeModal}>X</button>
-        </LoginTop>
-        <LogoArea>
-          <LogoCharacter src="/images/logo_character.jpg" />
-          <Logo alt="logo" src="/images/logo.png" />
-          <p>Paint Everything Around Me</p>
-        </LogoArea>
-        <KakaoArea>
-          <KakaoOauthBtn href={KAKAO_OAUTH_URL}>
-            <img
-              alt="loginButton"
-              src="/images/Login/kakao_login_large_wide.png"
-            />
-          </KakaoOauthBtn>
-          <LoginTypeTwo>
-            <Direction>계정정보 직접 입력하여 로그인하기</Direction>
-            <Input
-              type="text"
-              placeholder="카카오메일 아이디, 이메일, 전화번호"
-              name="id"
-              value={userData.id}
-              onChange={handleInput}
-            />
-            <Input
-              type="password"
-              placeholder="비밀번호"
-              name="pw"
-              value={userData.pw}
-              onChange={handleInput}
-            />
-            <Button disabled={disabled}>로그인</Button>
-          </LoginTypeTwo>
-        </KakaoArea>
-        <LoginCaution>로그인 완료시 상세정보 확인 가능</LoginCaution>
-      </LoginArea>
-    </>
-  );
+  if (!loginModalState) return null;
+  else {
+    return (
+      <>
+        <Overlay onClick={closeLoginModal} />
+        <LoginArea
+          disabled={disabled}
+          onKeyUp={e => {
+            if (e.key === 'Escape') {
+              return closeLoginModal;
+            }
+          }}
+        >
+          <LoginTop>
+            <span />
+            <button onClick={closeLoginModal}>X</button>
+          </LoginTop>
+          <LogoArea>
+            <LogoCharacter src="/images/logo_character.jpg" />
+            <Logo alt="logo" src="/images/logo.png" />
+            <p>Paint Everything Around Me</p>
+          </LogoArea>
+          <KakaoArea>
+            <KakaoOauthBtn href={KAKAO_OAUTH_URL}>
+              <img
+                alt="loginButton"
+                src="/images/Login/kakao_login_large_wide.png"
+              />
+            </KakaoOauthBtn>
+            <LoginTypeTwo>
+              <Direction>계정정보 직접 입력하여 로그인하기</Direction>
+              <Input
+                type="text"
+                placeholder="카카오메일 아이디, 이메일, 전화번호"
+                name="id"
+                value={userData.id}
+                onChange={handleInput}
+              />
+              <Input
+                type="password"
+                placeholder="비밀번호"
+                name="pw"
+                value={userData.pw}
+                onChange={handleInput}
+              />
+              <Button disabled={disabled}>로그인</Button>
+            </LoginTypeTwo>
+          </KakaoArea>
+          <LoginCaution>로그인 완료시 상세정보 확인 가능</LoginCaution>
+        </LoginArea>
+      </>
+    );
+  }
 };
 
 const Overlay = styled.div`

--- a/src/components/Nav/Login/OauthHandler.js
+++ b/src/components/Nav/Login/OauthHandler.js
@@ -1,7 +1,55 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import styled from 'styled-components';
+import { flexAlignCenter } from '../../../styles/mixin';
+import { LOGIN_API_URL } from '../../../config';
 
 const OAuthHandler = () => {
-  return <div>로그인 진행중</div>;
+  const location = useLocation();
+
+  useEffect(() => {
+    const authorizeCode = location.search.slice(6);
+    fetch(`${LOGIN_API_URL}/users/login?code=${authorizeCode}`)
+      .then(res => res.json())
+      .then(res => {
+        window.sessionStorage.setItem('JWT', res.access_token);
+      });
+  }, [location]);
+
+  return (
+    <OAth>
+      <Content>
+        <img alt="logo_character" src="/images/logo_character.jpg" />
+        <div> 소셜 로그인 진행 중 :) </div>
+      </Content>
+    </OAth>
+  );
 };
+
+const OAth = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: white;
+  z-index: 1000;
+`;
+
+const Content = styled.div`
+  ${flexAlignCenter}
+  flex-direction: column;
+  top: 50%;
+  right: 50%;
+  bottom: 50%;
+  left: 50%;
+  font-size: 5vh;
+
+  img {
+    width: 30%;
+    margin-top: 30vh;
+    margin-bottom: 5vh;
+  }
+`;
 
 export default OAuthHandler;

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -2,13 +2,16 @@ import React, { useState } from 'react';
 import Login from './Login/Login';
 
 const Nav = () => {
-  const [modalState, setModalState] = useState(false);
-  const closeModal = () => setModalState(false);
+  const [loginModalState, setLoginModalState] = useState(false);
+  const closeLoginModal = () => setLoginModalState(false);
 
   return (
-    <div onKeyUp={e => e.key === 'Escape' && setModalState(false)}>
-      <Login modalState={modalState} closeModal={closeModal} />
-      <button onClick={() => setModalState(true)}>로그인</button>
+    <div onKeyUp={e => e.key === 'Escape' && setLoginModalState(false)}>
+      <Login
+        loginModalState={loginModalState}
+        closeLoginModal={closeLoginModal}
+      />
+      <button onClick={() => setLoginModalState(true)}>로그인</button>
       <div>상단입니다.</div>
     </div>
   );

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,1 @@
+export const LOGIN_API_URL = 'http://13.124.44.115:8080';


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- Kakao Social login API 연동

<br />

## :: 구현 사항 설명
#### 1. Kakao Login API 활용하여 로그인 진행
1) REST API 방식으로 Kakao Login 인가코드 요청
  a. Kakao developers에 개인 어플리케이션 등록 후 발행된 <앱 REST API 키> 확인
  b. Kakao로부터 로그인 인가코드를 전달받을 < REDIRECT URI > 설정
  c. 로그인 모달창의 로그인 버튼 a태그 href에 인가코드 요청 URL 입력
    - Kakao 인가코드 발행 URL에 1)번과 2)번의 값을 query string 형식으로 포함하여, 해당 URL로 이동

2) GET 방식으로 Backend server에 인가코드 전달 후 JWT 값 받기
  a. 1-b)에서 설정한 < REDIRECT URI > 페이지를 구성하는 컴포넌트(`OathHandler.js`)를 Router.js에 추가
  b. Kakao에서 전송된 인가코드를 parsing하는 함수 추가
    - `useLocation()` hook의 `search()` 함수를 활용하여, URL의 querystring을 parsing
    - `slice()`함수를 활용하여, parsing된 querystring중 인가코드 영역만 변수에 할당
  c. 변수에 할당된 인가코드를 Backend server API URL의 querystring으로 포함하여 GET방식으로 전송
  d. Backend server로부터 response 값으로 전송된 'JWT'를 sessionStorage에 저장

- 테스트 방법 : `/list` 페이지 이동 >>> 로그인 버튼 선택 >>> 카카오 로그인 진행 >>> `/oauth` 페이지 콘솔창에 `sessionStorage.JWT` 입력


## :: 추가 구현 사항
- 로그인 버튼 선택의 경우, 상세페이지 관심상품 추가 OR 상세페이지 구매버튼 선택의 경우 로그인 완료 이후 이동 페이지 제어
  - useHistory() hook 활용

<br />

## :: 성장 포인트
- Kakao social login API의 인가코드 발급, 인증토큰 발급, 사용자 데이터 요청 구조를 이해하게 됨
- REDIRECT URI에 query string이 추가되는 경우 router에서 인식할 수 있도록 추가해야함을 알게 됨
- useLocation() hook을 활용하는 방법을 터득함
- Backend server에서 Python으로 인증토큰을 발급받고, 사용자 데이터 요청하는 구조를 이해하게 됨