### PR TITLE
[feature / detailBtn] 상세 페이지 : 스크롤 시 show 되는 sticky 버튼 구현

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -7,6 +7,7 @@ import ProductsList from './pages/ProductsList/ProductsList';
 import OAuthHandler from './components/Nav/Login/OauthHandler';
 import ChartBox from './pages/ProductDetail/PriceChart/ChartBox';
 import Logout from './components/Nav/Login/Logout';
+import StickyBtnBox from './pages/ProductDetail/ProductDetailInfo/DetailBtn/StickyBtnBox';
 
 const Router = () => {
   return (
@@ -19,6 +20,7 @@ const Router = () => {
         <Route path="/oauth" element={<OAuthHandler />} />
         <Route path="/chart" element={<ChartBox />} />
         <Route path="/logout" element={<Logout />} />
+        <Route path="/btn" element={<StickyBtnBox />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/pages/ProductDetail/ProductDetailInfo/DetailBtn/StickyBtn.js
+++ b/src/pages/ProductDetail/ProductDetailInfo/DetailBtn/StickyBtn.js
@@ -1,0 +1,92 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import Button from '../Button';
+
+const SearchBar = () => {
+  const [isMainScroll, setIsMainScroll] = useState(true);
+
+  const listenScrollEvent = () => {
+    window.scrollY > 200 ? setIsMainScroll(true) : setIsMainScroll(false);
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', listenScrollEvent);
+    return () => {
+      window.removeEventListener('scroll', listenScrollEvent);
+    };
+  }, []);
+
+  const styledImg = {
+    width: '60px',
+    height: '60px',
+    borderRadius: '10px',
+  };
+
+  const margin = {
+    marginRight: '10px',
+    marginTop: '-4px',
+  };
+
+  return (
+    <div>
+      {isMainScroll && (
+        <Banner>
+          <InBox>
+            <img
+              src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT2tzEhvBhM6gLpVcCuokwKqoI-B-WWVdrH6g&usqp=CAU"
+              style={styledImg}
+              alt="img"
+            />
+            <Name>vincent van gogh</Name>
+          </InBox>
+          <ButtonBox>
+            <StyledButton>
+              <span style={margin}>구매</span>
+              <div style={margin}>260,000원</div>
+            </StyledButton>
+            <StyledButton sell>
+              <span style={margin}>구매</span>
+              <div style={margin}>260,000원</div>
+            </StyledButton>
+          </ButtonBox>
+        </Banner>
+      )}
+    </div>
+  );
+};
+
+const Banner = styled.div`
+  position: fixed;
+  display: flex;
+  justify-content: space-between;
+  top: 99px;
+  width: 100vw;
+  padding: 10px 40px 15px;
+  background-color: white;
+  box-shadow: 4px 0 10px 0 rgb(0 0 0 / 10%);
+  z-index: 1;
+`;
+
+const InBox = styled.div`
+  display: flex;
+  width: 100%;
+`;
+
+const Name = styled.div`
+  font-size: ${({ theme }) => theme.fontsize.fontSize2};
+  margin: 5px 10px;
+`;
+
+const ButtonBox = styled.div`
+  display: flex;
+  align-items: center;
+  width: 55%;
+`;
+
+const StyledButton = styled(Button)`
+  width: 100%;
+  height: 50px;
+  margin-left: 10px;
+`;
+
+export default SearchBar;

--- a/src/pages/ProductDetail/ProductDetailInfo/DetailBtn/StickyBtnBox.js
+++ b/src/pages/ProductDetail/ProductDetailInfo/DetailBtn/StickyBtnBox.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import styled from 'styled-components';
+import StickyBtn from './StickyBtn';
+
+const StickyBtnBox = () => {
+  return (
+    <OutBox>
+      <StickyBtn></StickyBtn>
+    </OutBox>
+  );
+};
+
+const OutBox = styled.div`
+  height: 20000px;
+`;
+
+export default StickyBtnBox;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 상세페이지에서 스크롤 내릴 때 보여지는 sticky 버튼 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 상세페이지 : 스크롤 시 show 되는 sticky 버튼 구현
- 상세페이지에서 해당 제품의 정보와 구매, 판매 버튼이 들어가있는 박스를 정해진 스크롤 시점에서 보여지게 하도록 함
- addEventListener & removeEventListener 메서드를 사용하여 구현

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 평상시에 주로 요소에 inline 으로 이벤트 리스너를 넣었던 onClick 메서드와는 다른 addEventListener 메서드를 사용해봄으로써 두가지 이벤트핸들러에 대한 차이점에 대해 알 수 있게 되었습니다.

<br />

## :: 기타 질문 및 특이 사항
- 개인적으로 궁금한건데 addEventListener 가 이벤트 버블링을 설정할 수 있고 제어가 가능하다 라고 되어있는데요, 그럼 원하지 않을 때 이벤트 버블링이 일어나면 onClick 메서드를 사용하는 것보다 addEventListener 메서드를 사용해야 제어가 간편한 편인가요?
